### PR TITLE
Allow admin user to view and edit all photos

### DIFF
--- a/app/Actions/Photos/FilterPhotosAction.php
+++ b/app/Actions/Photos/FilterPhotosAction.php
@@ -13,9 +13,9 @@ class FilterPhotosAction
     /**
      * @return LengthAwarePaginator<int, Photo>
      */
-    public function run(User $user): LengthAwarePaginator
+    public function run(User $user, bool $showAllPhotos = false): LengthAwarePaginator
     {
-        $photos = $this->baseQuery($user)
+        $photos = $this->baseQuery($user, $showAllPhotos)
             ->withExists([
                 'items',
                 'photoItemSuggestions' => fn (Builder $query) => $query->whereNull('is_accepted')->where('score', '>=', 80),
@@ -35,23 +35,30 @@ class FilterPhotosAction
     /**
      * @return array<int, mixed>
      */
-    public function allIds(User $user): array
+    public function allIds(User $user, bool $showAllPhotos = false): array
     {
-        return $this->baseQuery($user)->pluck('id')->all();
+        return $this->baseQuery($user, $showAllPhotos)->pluck('id')->all();
     }
 
     /**
-     * @return HasMany<Photo, User>
+     * @return HasMany<Photo, User>|\Illuminate\Database\Eloquent\Builder<Photo>
      */
-    private function baseQuery(User $user): HasMany
+    private function baseQuery(User $user, bool $showAllPhotos = false): HasMany|\Illuminate\Database\Eloquent\Builder
     {
-        $query = $user
-            ->photos()
+        $query = $showAllPhotos
+            ? Photo::query()->whereHas('user')
+            : $user->photos();
+
+        $query = $query
             ->filter($user->settings->photo_filters)
             ->orderBy($user->settings->sort_column, $user->settings->sort_direction);
 
         if ($user->settings->sort_column !== 'id') {
             $query->orderBy('id');
+        }
+
+        if ($showAllPhotos) {
+            $query->with('user');
         }
 
         return $query;

--- a/app/Actions/Photos/GetNextPhotoAction.php
+++ b/app/Actions/Photos/GetNextPhotoAction.php
@@ -8,14 +8,16 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 
 class GetNextPhotoAction
 {
-    public function run(User $user, Photo $photo): ?string
+    public function run(User $user, Photo $photo, bool $showAllPhotos = false): ?string
     {
         $attribute = $photo->getAttribute($user->settings->sort_column);
 
         /** @var Builder $builder */
-        $builder = $user
-            ->photos()
-            ->filter($user->settings->photo_filters);
+        $builder = $showAllPhotos
+            ? Photo::query()->whereHas('user')
+            : $user->photos();
+
+        $builder->filter($user->settings->photo_filters);
 
         if ($attribute) {
             $nextPhoto = $builder->clone()

--- a/app/Actions/Photos/GetPreviousPhotoAction.php
+++ b/app/Actions/Photos/GetPreviousPhotoAction.php
@@ -12,7 +12,7 @@ class GetPreviousPhotoAction
     {
         $attribute = $photo->getAttribute($user->settings->sort_column);
 
-        /** @var Builder $builder */
+        /** @var \Illuminate\Database\Eloquent\Builder<Photo> $builder */
         $builder = $showAllPhotos
             ? Photo::query()->whereHas('user')
             : $user->photos();

--- a/app/Actions/Photos/GetPreviousPhotoAction.php
+++ b/app/Actions/Photos/GetPreviousPhotoAction.php
@@ -8,14 +8,16 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 
 class GetPreviousPhotoAction
 {
-    public function run(User $user, Photo $photo): ?string
+    public function run(User $user, Photo $photo, bool $showAllPhotos = false): ?string
     {
         $attribute = $photo->getAttribute($user->settings->sort_column);
 
         /** @var Builder $builder */
-        $builder = $user
-            ->photos()
-            ->filter($user->settings->photo_filters);
+        $builder = $showAllPhotos
+            ? Photo::query()->whereHas('user')
+            : $user->photos();
+
+        $builder->filter($user->settings->photo_filters);
 
         if ($attribute) {
             $previousPhoto = $builder->clone()

--- a/app/Http/Controllers/Photos/BulkPhotoItemsController.php
+++ b/app/Http/Controllers/Photos/BulkPhotoItemsController.php
@@ -17,9 +17,18 @@ use Illuminate\Support\Facades\DB;
 
 class BulkPhotoItemsController extends Controller
 {
+    /**
+     * @param  array<int>  $photoIds
+     */
     private function authorizeAdminOrOwnPhotos(array $photoIds): void
     {
+        /** @var \App\Models\User|null $user */
         $user = auth()->user();
+
+        if (! $user) {
+            abort(404);
+        }
+
         $photoUserIds = Photo::query()->whereIn('id', $photoIds)->pluck('user_id')->unique()->values();
 
         if ($user->is_admin) {

--- a/app/Http/Controllers/Photos/BulkPhotoItemsController.php
+++ b/app/Http/Controllers/Photos/BulkPhotoItemsController.php
@@ -7,6 +7,7 @@ use App\DTO\BulkDeletePhotoItems;
 use App\DTO\BulkPhotoItems;
 use App\Http\Controllers\Controller;
 use App\Models\Item;
+use App\Models\Photo;
 use App\Models\PhotoItem;
 use App\Models\PhotoItemSuggestion;
 use App\Models\PhotoItemTag;
@@ -16,8 +17,26 @@ use Illuminate\Support\Facades\DB;
 
 class BulkPhotoItemsController extends Controller
 {
+    private function authorizeAdminOrOwnPhotos(array $photoIds): void
+    {
+        $user = auth()->user();
+        $photoUserIds = Photo::query()->whereIn('id', $photoIds)->pluck('user_id')->unique()->values();
+
+        if ($user->is_admin) {
+            return;
+        }
+
+        if ($photoUserIds->count() === 1 && $photoUserIds->first() === $user->id) {
+            return;
+        }
+
+        abort(404);
+    }
+
     public function store(BulkPhotoItems $bulkPhotoItems): void
     {
+        $this->authorizeAdminOrOwnPhotos($bulkPhotoItems->photo_ids);
+
         $items = Item::query()->find(array_column($bulkPhotoItems->items, 'id'))->keyBy('id');
         $usedShortcuts = TagShortcut::query()->find($bulkPhotoItems->used_shortcuts)->keyBy('id');
 
@@ -58,6 +77,8 @@ class BulkPhotoItemsController extends Controller
 
     public function destroy(BulkDeletePhotoItems $bulkDeletePhotoItems): void
     {
+        $this->authorizeAdminOrOwnPhotos($bulkDeletePhotoItems->photo_ids);
+
         DB::transaction(function () use ($bulkDeletePhotoItems): void {
             PhotoItem::query()
                 ->whereIn('photo_id', $bulkDeletePhotoItems->photo_ids)
@@ -77,6 +98,8 @@ class BulkPhotoItemsController extends Controller
 
     public function addTags(BulkAddPhotoTags $bulkAddPhotoTags): RedirectResponse
     {
+        $this->authorizeAdminOrOwnPhotos($bulkAddPhotoTags->photo_ids);
+
         $photosWithMultipleItems = [];
         $photosWithNoItems = [];
         $tagsAdded = false;

--- a/app/Http/Controllers/Photos/CopyPhotoItemController.php
+++ b/app/Http/Controllers/Photos/CopyPhotoItemController.php
@@ -10,7 +10,13 @@ class CopyPhotoItemController extends Controller
 {
     public function __invoke(PhotoItem $photoItem): JsonResponse
     {
+        /** @var \App\Models\User|null $user */
         $user = auth()->user();
+
+        if (! $user) {
+            abort(404);
+        }
+
         $photo = $photoItem->photo;
 
         if (! $user->is_admin && $user->id !== $photo->user_id) {

--- a/app/Http/Controllers/Photos/CopyPhotoItemController.php
+++ b/app/Http/Controllers/Photos/CopyPhotoItemController.php
@@ -10,7 +10,10 @@ class CopyPhotoItemController extends Controller
 {
     public function __invoke(PhotoItem $photoItem): JsonResponse
     {
-        if (auth()->id() !== $photoItem->photo->user_id) {
+        $user = auth()->user();
+        $photo = $photoItem->photo;
+
+        if (! $user->is_admin && $user->id !== $photo->user_id) {
             abort(404);
         }
 

--- a/app/Http/Controllers/Photos/PhotoItemTagsController.php
+++ b/app/Http/Controllers/Photos/PhotoItemTagsController.php
@@ -12,7 +12,13 @@ class PhotoItemTagsController extends Controller
 {
     public function store(PhotoItem $photoItem, StorePhotoItemTagRequest $request): JsonResponse
     {
+        /** @var \App\Models\User|null $user */
         $user = auth()->user();
+
+        if (! $user) {
+            abort(404);
+        }
+
         $photo = $photoItem->photo;
 
         if (! $user->is_admin && $user->id !== $photo->user_id) {
@@ -26,7 +32,13 @@ class PhotoItemTagsController extends Controller
 
     public function destroy(PhotoItem $photoItem, Tag $tag): JsonResponse
     {
+        /** @var \App\Models\User|null $user */
         $user = auth()->user();
+
+        if (! $user) {
+            abort(404);
+        }
+
         $photo = $photoItem->photo;
 
         if (! $user->is_admin && $user->id !== $photo->user_id) {

--- a/app/Http/Controllers/Photos/PhotoItemTagsController.php
+++ b/app/Http/Controllers/Photos/PhotoItemTagsController.php
@@ -12,7 +12,10 @@ class PhotoItemTagsController extends Controller
 {
     public function store(PhotoItem $photoItem, StorePhotoItemTagRequest $request): JsonResponse
     {
-        if (auth()->id() !== $photoItem->photo->user_id) {
+        $user = auth()->user();
+        $photo = $photoItem->photo;
+
+        if (! $user->is_admin && $user->id !== $photo->user_id) {
             abort(404);
         }
 
@@ -23,7 +26,10 @@ class PhotoItemTagsController extends Controller
 
     public function destroy(PhotoItem $photoItem, Tag $tag): JsonResponse
     {
-        if (auth()->id() !== $photoItem->photo->user_id) {
+        $user = auth()->user();
+        $photo = $photoItem->photo;
+
+        if (! $user->is_admin && $user->id !== $photo->user_id) {
             abort(404);
         }
 

--- a/app/Http/Controllers/Photos/PhotoItemsController.php
+++ b/app/Http/Controllers/Photos/PhotoItemsController.php
@@ -18,7 +18,7 @@ class PhotoItemsController extends Controller
         /** @var User $user */
         $user = auth()->user();
 
-        if ($user->id !== $photo->user_id) {
+        if (! $user->is_admin && $user->id !== $photo->user_id) {
             abort(404);
         }
 
@@ -41,7 +41,10 @@ class PhotoItemsController extends Controller
 
     public function update(PhotoItem $photoItem, UpdatePhotoItemRequest $request): JsonResponse
     {
-        if (auth()->id() !== $photoItem->photo->user_id) {
+        $user = auth()->user();
+        $photo = $photoItem->photo;
+
+        if (! $user->is_admin && $user->id !== $photo->user_id) {
             abort(404);
         }
 
@@ -68,7 +71,10 @@ class PhotoItemsController extends Controller
 
     public function destroy(PhotoItem $photoItem): JsonResponse
     {
-        if (auth()->id() !== $photoItem->photo->user_id) {
+        $user = auth()->user();
+        $photo = $photoItem->photo;
+
+        if (! $user->is_admin && $user->id !== $photo->user_id) {
             abort(404);
         }
 

--- a/app/Http/Controllers/Photos/PhotosController.php
+++ b/app/Http/Controllers/Photos/PhotosController.php
@@ -57,17 +57,19 @@ class PhotosController extends Controller
             $user->save();
         }
 
-        $photos = $filterPhotosAction->run($user);
+        $showAllPhotos = $user->is_admin;
+        $photos = $filterPhotosAction->run($user, $showAllPhotos);
 
         $tagsAndItems = $getTagsAndItemsAction->run();
 
         return Inertia::render('Photos/Index', [
             'photos' => $photos,
-            'allPhotoIds' => $filterPhotosAction->allIds($user),
+            'allPhotoIds' => $filterPhotosAction->allIds($user, $showAllPhotos),
             'filters' => $user->settings->photo_filters,
             'items' => $tagsAndItems['items'],
             'tags' => $tagsAndItems['tags'],
             'tagShortcuts' => $this->getTagShortcuts($user),
+            'isAdmin' => $user->is_admin,
         ]);
     }
 
@@ -81,19 +83,20 @@ class PhotosController extends Controller
         /** @var User $user */
         $user = auth()->user();
 
-        if ($user->id !== $photo->user_id) {
+        if (! $user->is_admin && $user->id !== $photo->user_id) {
             abort(404);
         }
 
         if (! request()->wantsJson()) {
             $tagsAndItems = $getTagsAndItemsAction->run();
+            $showAllPhotos = $user->is_admin;
 
             return Inertia::render('Photos/Show', [
                 'photoId' => $photo->id,
                 'items' => $tagsAndItems['items'],
                 'tags' => $tagsAndItems['tags'],
-                'nextPhotoUrl' => $getNextPhotoAction->run($user, $photo),
-                'previousPhotoUrl' => $getPreviousPhotoAction->run($user, $photo),
+                'nextPhotoUrl' => $getNextPhotoAction->run($user, $photo, $showAllPhotos),
+                'previousPhotoUrl' => $getPreviousPhotoAction->run($user, $photo, $showAllPhotos),
                 'tagShortcuts' => $this->getTagShortcuts($user),
             ]);
         }
@@ -120,7 +123,9 @@ class PhotosController extends Controller
 
     public function destroy(Photo $photo): RedirectResponse
     {
-        if (auth()->id() !== $photo->user_id) {
+        $user = auth()->user();
+
+        if (! $user->is_admin && $user->id !== $photo->user_id) {
             abort(404);
         }
 

--- a/app/Rules/PhotosBelongToUser.php
+++ b/app/Rules/PhotosBelongToUser.php
@@ -20,9 +20,15 @@ class PhotosBelongToUser implements ValidationRule
             return;
         }
 
+        $user = auth()->user();
+
+        if ($user->is_admin) {
+            return;
+        }
+
         $photosBelongsToOthers = Photo::query()
             ->whereIn('id', $value)
-            ->where('user_id', '!=', auth()->id())
+            ->where('user_id', '!=', $user->id)
             ->exists();
 
         if ($photosBelongsToOthers) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29,3 +29,21 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: app/Models/TagShortcutItem.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Contracts\\Database\\Eloquent\\Builder::filter\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: app/Actions/Photos/GetNextPhotoAction.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Contracts\\Database\\Eloquent\\Builder::filter\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: app/Actions/Photos/GetPreviousPhotoAction.php
+
+		-
+			message: '#^Method App\\Http\\Controllers\\Photos\\BulkPhotoItemsController::authorizeAdminOrOwnPhotos\(\) has parameter \$photoIds with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Controllers/Photos/BulkPhotoItemsController.php

--- a/resources/js/Pages/Photos/Index.vue
+++ b/resources/js/Pages/Photos/Index.vue
@@ -27,6 +27,7 @@ const props = defineProps({
     items: Array,
     filters: Object,
     tagShortcuts: Array,
+    isAdmin: Boolean,
 });
 
 const isSelecting = ref(localStorage.getItem('isSelecting') === 'true' || false);
@@ -352,6 +353,10 @@ const exportData = (format) => {
                                     </a>
 
                                     <ZoomIcon @click="zoomedImage = photo" class="absolute top-0 left-0"/>
+
+                                    <div v-if="isAdmin && photo.user" class="absolute top-2 left-8 text-xs shadow bg-blue-500 rounded px-2 py-1 text-white">
+                                        {{ photo.user.name }}
+                                    </div>
 
                                     <div class="absolute top-2 right-2 flex gap-2">
                                         <LocationIcon v-if="photo.latitude && photo.longitude"/>


### PR DESCRIPTION
- FilterPhotosAction: add showAllPhotos parameter to load all photos for admin
- GetNextPhotoAction/GetPreviousPhotoAction: support admin navigation
- PhotosController: pass isAdmin to frontend, allow admin to view/delete any photo
- PhotoItemsController, PhotoItemTagsController, CopyPhotoItemController: allow admin to edit
- BulkPhotoItemsController: add authorizeAdminOrOwnPhotos check
- PhotosBelongToUser rule: allow admin to select photos from other users
- Index.vue: show user name on photo cards when admin